### PR TITLE
Add Inertia 2.3 Precognition support for live form validation

### DIFF
--- a/app/Http/Middleware/HandlePrecognitiveRequests.php
+++ b/app/Http/Middleware/HandlePrecognitiveRequests.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Support\PrecognitionControllerDispatcher;
+use Illuminate\Foundation\Http\Middleware\HandlePrecognitiveRequests as BaseHandlePrecognitiveRequests;
+use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
+
+/**
+ * Custom Precognition middleware that works with lorisleiva/laravel-actions.
+ *
+ * @see https://github.com/lorisleiva/laravel-actions/discussions/249
+ */
+class HandlePrecognitiveRequests extends BaseHandlePrecognitiveRequests
+{
+    /**
+     * Prepare to handle a precognitive request.
+     */
+    protected function prepareForPrecognition($request): void
+    {
+        parent::prepareForPrecognition($request);
+
+        // Override the dispatcher binding with our custom one that handles laravel-actions
+        $this->container->bind(
+            ControllerDispatcherContract::class,
+            fn ($app) => new PrecognitionControllerDispatcher($app)
+        );
+    }
+}

--- a/app/Support/PrecognitionControllerDispatcher.php
+++ b/app/Support/PrecognitionControllerDispatcher.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+use Illuminate\Container\Container;
+use Illuminate\Foundation\Routing\PrecognitionControllerDispatcher as BasePrecognitionControllerDispatcher;
+use Illuminate\Routing\Route;
+use Lorisleiva\Actions\Decorators\ControllerDecorator;
+
+/**
+ * Custom Precognition dispatcher that works with lorisleiva/laravel-actions.
+ *
+ * The issue is that laravel-actions wraps action classes in a ControllerDecorator,
+ * which causes Precognition to fail because it can't find the method on the decorator.
+ * This dispatcher extracts the actual action class from the route definition.
+ *
+ * @see https://github.com/lorisleiva/laravel-actions/discussions/249
+ */
+class PrecognitionControllerDispatcher extends BasePrecognitionControllerDispatcher
+{
+    public function __construct(Container $container)
+    {
+        parent::__construct($container);
+    }
+
+    /**
+     * Dispatch a request to a given controller and method.
+     *
+     * @param  mixed  $controller
+     * @param  string  $method
+     */
+    public function dispatch(Route $route, $controller, $method): void
+    {
+        // If the controller is a ControllerDecorator from laravel-actions,
+        // extract the actual action class from the route definition
+        if ($controller instanceof ControllerDecorator) {
+            $controllerClass = $route->action['controller'] ?? null;
+
+            if (is_string($controllerClass)) {
+                // Parse "App\Actions\User\UpdateProfile@asController" format
+                if (str_contains($controllerClass, '@')) {
+                    [$controllerClass] = explode('@', $controllerClass);
+                }
+
+                // Create an instance of the action class for method checking
+                $actionInstance = $this->container->make($controllerClass);
+
+                $this->ensureMethodExists($actionInstance, $method);
+                $this->resolveParameters($route, $actionInstance, $method);
+
+                abort(204, headers: ['Precognition-Success' => 'true']);
+            }
+        }
+
+        // Fall back to parent implementation for non-action controllers
+        parent::dispatch($route, $controller, $method);
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
                 "@biomejs/biome": "^2.3.8",
                 "@gfazioli/mantine-split-pane": "^1.1.5",
                 "@headlessui/react": "^2.2.9",
-                "@inertiajs/react": "^2.2.19",
+                "@inertiajs/react": "^2.3.1",
                 "@mantine/charts": "^8.3.9",
                 "@mantine/core": "^8.3.9",
                 "@mantine/hooks": "^8.3.9",
@@ -1035,27 +1035,29 @@
             }
         },
         "node_modules/@inertiajs/core": {
-            "version": "2.2.19",
-            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-2.2.19.tgz",
-            "integrity": "sha512-W0hp92AzusxxYIzthw9VbFt3ZMu4+SrtJBOF9bR2ljcU6r2b9JTauidf1+oxO1NfLnQN80uvt7tBJ015BNVJ4w==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@inertiajs/core/-/core-2.3.1.tgz",
+            "integrity": "sha512-K/v/e+HDDkC3FFLbi6GePU49cvYtRKx+KexslotudR3k/JwpKuwseo+sp4tSVPr3FkEfIP7VcC8kHOXSrOmobQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/lodash-es": "^4.17.12",
                 "axios": "^1.13.2",
+                "laravel-precognition": "^1.0.0",
                 "lodash-es": "^4.17.21",
                 "qs": "^6.14.0"
             }
         },
         "node_modules/@inertiajs/react": {
-            "version": "2.2.19",
-            "resolved": "https://registry.npmjs.org/@inertiajs/react/-/react-2.2.19.tgz",
-            "integrity": "sha512-G70j9tvslirO0MpkkSqR1LQiiWT70IgvMzIaNruRfyJcj8K2yfWrYcf+ym8Ep1YOtRxkbuUqVFF8TXDNACk/4w==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@inertiajs/react/-/react-2.3.1.tgz",
+            "integrity": "sha512-1hOQxRPqJ8NFG2Rnw+6o+0bO/Jlz3qR5w1V48d1sboi2fhVrXLXANvgAZgySrmhJyPO2UmUP+4UDx+ze4hFNLQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@inertiajs/core": "2.2.19",
+                "@inertiajs/core": "2.3.1",
                 "@types/lodash-es": "^4.17.12",
+                "laravel-precognition": "^1.0.0",
                 "lodash-es": "^4.17.21"
             },
             "peerDependencies": {
@@ -2982,6 +2984,17 @@
             },
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/laravel-precognition": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/laravel-precognition/-/laravel-precognition-1.0.0.tgz",
+            "integrity": "sha512-hvXPT7dayCQAidxnsY0hab9Q+Y2rsh7xRpH9uiFtXN8Dekc3tIZt+NrxrOZ9N5SwHBmRBze/Bv+ElfXac0kD6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "axios": "^1.4.0",
+                "lodash-es": "^4.17.21"
             }
         },
         "node_modules/laravel-vite-plugin": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "@biomejs/biome": "^2.3.8",
         "@gfazioli/mantine-split-pane": "^1.1.5",
         "@headlessui/react": "^2.2.9",
-        "@inertiajs/react": "^2.2.19",
+        "@inertiajs/react": "^2.3.1",
         "@mantine/charts": "^8.3.9",
         "@mantine/core": "^8.3.9",
         "@mantine/hooks": "^8.3.9",

--- a/resources/js/Pages/Auth/ConfirmPassword.tsx
+++ b/resources/js/Pages/Auth/ConfirmPassword.tsx
@@ -7,9 +7,11 @@ import TextInput from '@/Components/Breeze/TextInput';
 import GuestLayout from '@/Layouts/GuestLayout';
 
 export default function ConfirmPassword() {
-    const { data, setData, post, processing, errors, reset } = useForm({
+    const form = useForm({
         password: '',
-    });
+    }).withPrecognition('post', route('password.confirm'));
+
+    const { data, setData, post, processing, errors, reset, validate } = form;
 
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
@@ -40,6 +42,7 @@ export default function ConfirmPassword() {
                         className="mt-1 block w-full"
                         isFocused={true}
                         onChange={(e) => setData('password', e.target.value)}
+                        onBlur={() => validate('password')}
                     />
 
                     <InputError message={errors.password} className="mt-2" />

--- a/resources/js/Pages/Auth/ForgotPassword.tsx
+++ b/resources/js/Pages/Auth/ForgotPassword.tsx
@@ -6,9 +6,11 @@ import TextInput from '@/Components/Breeze/TextInput';
 import GuestLayout from '@/Layouts/GuestLayout';
 
 export default function ForgotPassword({ status }: { status?: string }) {
-    const { data, setData, post, processing, errors } = useForm({
+    const form = useForm({
         email: '',
-    });
+    }).withPrecognition('post', route('password.email'));
+
+    const { data, setData, post, processing, errors, validate } = form;
 
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
@@ -41,6 +43,7 @@ export default function ForgotPassword({ status }: { status?: string }) {
                     className="mt-1 block w-full"
                     isFocused={true}
                     onChange={(e) => setData('email', e.target.value)}
+                    onBlur={() => validate('email')}
                 />
 
                 <InputError message={errors.email} className="mt-2" />

--- a/resources/js/Pages/Auth/Login.tsx
+++ b/resources/js/Pages/Auth/Login.tsx
@@ -25,11 +25,13 @@ export default function Login({
     canResetPassword,
     canRegister,
 }: Props) {
-    const { data, setData, post, processing, errors, reset } = useForm({
+    const form = useForm({
         email: '',
         password: '',
         remember: false as boolean,
-    });
+    }).withPrecognition('post', route('login'));
+
+    const { data, setData, post, processing, errors, reset, validate } = form;
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
@@ -78,6 +80,7 @@ export default function Login({
                     required
                     value={data.email}
                     onChange={(e) => setData('email', e.target.value)}
+                    onBlur={() => validate('email')}
                     error={errors.email}
                     autoComplete="username"
                 />
@@ -89,6 +92,7 @@ export default function Login({
                     mt="md"
                     value={data.password}
                     onChange={(e) => setData('password', e.target.value)}
+                    onBlur={() => validate('password')}
                     error={errors.password}
                     autoComplete="current-password"
                 />

--- a/resources/js/Pages/Auth/Register.tsx
+++ b/resources/js/Pages/Auth/Register.tsx
@@ -12,12 +12,14 @@ import {
 import classes from './Register.module.css';
 
 export default function Register() {
-    const { data, setData, post, processing, errors, reset } = useForm({
+    const form = useForm({
         name: '',
         email: '',
         password: '',
         password_confirmation: '',
-    });
+    }).withPrecognition('post', route('register'));
+
+    const { data, setData, post, processing, errors, reset, validate } = form;
 
     const handleSubmit = (e: React.FormEvent) => {
         e.preventDefault();
@@ -59,6 +61,7 @@ export default function Register() {
                     required
                     value={data.name}
                     onChange={(e) => setData('name', e.target.value)}
+                    onBlur={() => validate('name')}
                     error={errors.name}
                     autoComplete="name"
                 />
@@ -70,6 +73,7 @@ export default function Register() {
                     mt="md"
                     value={data.email}
                     onChange={(e) => setData('email', e.target.value)}
+                    onBlur={() => validate('email')}
                     error={errors.email}
                     autoComplete="username"
                 />
@@ -81,6 +85,7 @@ export default function Register() {
                     mt="md"
                     value={data.password}
                     onChange={(e) => setData('password', e.target.value)}
+                    onBlur={() => validate('password')}
                     error={errors.password}
                     autoComplete="new-password"
                 />
@@ -94,6 +99,7 @@ export default function Register() {
                     onChange={(e) =>
                         setData('password_confirmation', e.target.value)
                     }
+                    onBlur={() => validate('password_confirmation')}
                     error={errors.password_confirmation}
                     autoComplete="new-password"
                 />

--- a/resources/js/Pages/Auth/ResetPassword.tsx
+++ b/resources/js/Pages/Auth/ResetPassword.tsx
@@ -13,12 +13,14 @@ export default function ResetPassword({
     token: string;
     email: string;
 }) {
-    const { data, setData, post, processing, errors, reset } = useForm({
+    const form = useForm({
         token: token,
         email: email,
         password: '',
         password_confirmation: '',
-    });
+    }).withPrecognition('post', route('password.store'));
+
+    const { data, setData, post, processing, errors, reset, validate } = form;
 
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
@@ -44,6 +46,7 @@ export default function ResetPassword({
                         className="mt-1 block w-full"
                         autoComplete="username"
                         onChange={(e) => setData('email', e.target.value)}
+                        onBlur={() => validate('email')}
                     />
 
                     <InputError message={errors.email} className="mt-2" />
@@ -61,6 +64,7 @@ export default function ResetPassword({
                         autoComplete="new-password"
                         isFocused={true}
                         onChange={(e) => setData('password', e.target.value)}
+                        onBlur={() => validate('password')}
                     />
 
                     <InputError message={errors.password} className="mt-2" />
@@ -81,6 +85,7 @@ export default function ResetPassword({
                         onChange={(e) =>
                             setData('password_confirmation', e.target.value)
                         }
+                        onBlur={() => validate('password_confirmation')}
                     />
 
                     <InputError

--- a/resources/js/Pages/Reader/Components/UpdateFeedModal.tsx
+++ b/resources/js/Pages/Reader/Components/UpdateFeedModal.tsx
@@ -103,7 +103,7 @@ export const UpdateFeedModal = ({
     opened,
     onClose,
 }: UpdateFeedModalProps) => {
-    const { data, setData, errors, processing, patch, transform } = useForm<{
+    const form = useForm<{
         category_id: number;
         name: string;
         filter_rules: FilterRules;
@@ -115,7 +115,10 @@ export const UpdateFeedModal = ({
             exclude_content: feed.filter_rules?.exclude_content ?? [],
             exclude_author: feed.filter_rules?.exclude_author ?? [],
         },
-    });
+    }).withPrecognition('patch', route('feed.update', feed.id));
+
+    const { data, setData, errors, processing, patch, transform, validate } =
+        form;
 
     // Clean up empty filter values before submitting
     transform((data) => ({
@@ -208,6 +211,7 @@ export const UpdateFeedModal = ({
                         data-autofocus
                         value={data.name}
                         onChange={(e) => setData('name', e.target.value)}
+                        onBlur={() => validate('name')}
                         withErrorStyles={false}
                         rightSectionPointerEvents="none"
                         rightSection={

--- a/resources/js/Pages/Reader/Sidebar.tsx
+++ b/resources/js/Pages/Reader/Sidebar.tsx
@@ -637,11 +637,14 @@ const AddFeedForm = function AddFeedForm({
     const initialCategorySelection =
         categories.length > 0 ? categories[0].id.toString() : 'new';
 
-    const { data, setData, post, errors, processing, transform } = useForm({
+    const form = useForm({
         feed_url: initialFeedURL || '',
         category_selection: initialCategorySelection,
         category_name: '',
-    });
+    }).withPrecognition('post', route('feed.store'));
+
+    const { data, setData, post, errors, processing, transform, validate } =
+        form;
 
     // Transform the feed URL to have a protocol if it doesn't have one
     transform((data) => {
@@ -727,6 +730,7 @@ const AddFeedForm = function AddFeedForm({
                 data-autofocus
                 value={data.feed_url}
                 onChange={(e) => setData('feed_url', e.target.value)}
+                onBlur={() => validate('feed_url')}
                 error={errors.feed_url}
             />
 
@@ -817,6 +821,7 @@ const AddFeedForm = function AddFeedForm({
                     }
                     value={data.category_name}
                     onChange={(e) => setData('category_name', e.target.value)}
+                    onBlur={() => validate('category_name')}
                     error={errors.category_name}
                     data-autofocus={categories.length === 0}
                 />
@@ -844,9 +849,11 @@ const AddCategoryForm = function AddCategoryForm({
 }: {
     close: () => void;
 }) {
-    const { data, setData, post, errors, processing } = useForm({
+    const form = useForm({
         categoryName: '',
-    });
+    }).withPrecognition('post', route('category.store'));
+
+    const { data, setData, post, errors, processing, validate } = form;
 
     const submit: FormEventHandler = (e) => {
         e.preventDefault();
@@ -897,6 +904,7 @@ const AddCategoryForm = function AddCategoryForm({
                 data-autofocus
                 value={data.categoryName}
                 onChange={(e) => setData('categoryName', e.target.value)}
+                onBlur={() => validate('categoryName')}
                 withErrorStyles={false}
                 rightSectionPointerEvents="none"
                 rightSection={

--- a/resources/js/Pages/Settings/sections/ProfileSettings.tsx
+++ b/resources/js/Pages/Settings/sections/ProfileSettings.tsx
@@ -28,11 +28,20 @@ const ProfileSettings = ({ mustVerifyEmail, status }: ProfileSettingsProps) => {
         },
     } = usePage<PageProps>();
 
-    const { data, setData, patch, errors, processing, recentlySuccessful } =
-        useForm({
-            name: user.name,
-            email: user.email,
-        });
+    const profileForm = useForm({
+        name: user.name,
+        email: user.email,
+    }).withPrecognition('patch', route('profile.update'));
+
+    const {
+        data,
+        setData,
+        patch,
+        errors,
+        processing,
+        recentlySuccessful,
+        validate,
+    } = profileForm;
 
     const submitProfile: FormEventHandler = (event) => {
         event.preventDefault();
@@ -49,6 +58,12 @@ const ProfileSettings = ({ mustVerifyEmail, status }: ProfileSettingsProps) => {
         });
     };
 
+    const passwordForm = useForm({
+        current_password: '',
+        password: '',
+        password_confirmation: '',
+    }).withPrecognition('put', route('password.update'));
+
     const {
         data: passwordData,
         setData: setPasswordData,
@@ -56,11 +71,8 @@ const ProfileSettings = ({ mustVerifyEmail, status }: ProfileSettingsProps) => {
         errors: passwordErrors,
         processing: passwordProcessing,
         reset: resetPassword,
-    } = useForm({
-        current_password: '',
-        password: '',
-        password_confirmation: '',
-    });
+        validate: validatePassword,
+    } = passwordForm;
 
     const passwordInputRef = useRef<HTMLInputElement>(null);
     const currentPasswordInputRef = useRef<HTMLInputElement>(null);
@@ -91,6 +103,10 @@ const ProfileSettings = ({ mustVerifyEmail, status }: ProfileSettingsProps) => {
 
     const [deleteModalOpened, deleteModalHandlers] = useDisclosure(false);
     const deletePasswordRef = useRef<HTMLInputElement>(null);
+    const deleteForm = useForm({
+        password: '',
+    }).withPrecognition('delete', route('profile.destroy'));
+
     const {
         data: deleteData,
         setData: setDeleteData,
@@ -98,9 +114,8 @@ const ProfileSettings = ({ mustVerifyEmail, status }: ProfileSettingsProps) => {
         processing: deleteProcessing,
         errors: deleteErrors,
         reset: resetDelete,
-    } = useForm({
-        password: '',
-    });
+        validate: validateDelete,
+    } = deleteForm;
 
     const confirmDeletion: FormEventHandler = (event) => {
         event.preventDefault();
@@ -135,6 +150,7 @@ const ProfileSettings = ({ mustVerifyEmail, status }: ProfileSettingsProps) => {
                     onChange={(event) =>
                         setData('name', event.currentTarget.value)
                     }
+                    onBlur={() => validate('name')}
                     required
                     error={errors.name}
                     data-autofocus
@@ -146,6 +162,7 @@ const ProfileSettings = ({ mustVerifyEmail, status }: ProfileSettingsProps) => {
                     onChange={(event) =>
                         setData('email', event.currentTarget.value)
                     }
+                    onBlur={() => validate('email')}
                     required
                     error={errors.email}
                 />
@@ -211,6 +228,7 @@ const ProfileSettings = ({ mustVerifyEmail, status }: ProfileSettingsProps) => {
                             event.currentTarget.value,
                         )
                     }
+                    onBlur={() => validatePassword('current_password')}
                     error={passwordErrors.current_password}
                     ref={currentPasswordInputRef}
                     required
@@ -221,6 +239,7 @@ const ProfileSettings = ({ mustVerifyEmail, status }: ProfileSettingsProps) => {
                     onChange={(event) =>
                         setPasswordData('password', event.currentTarget.value)
                     }
+                    onBlur={() => validatePassword('password')}
                     error={passwordErrors.password}
                     ref={passwordInputRef}
                     required
@@ -234,6 +253,7 @@ const ProfileSettings = ({ mustVerifyEmail, status }: ProfileSettingsProps) => {
                             event.currentTarget.value,
                         )
                     }
+                    onBlur={() => validatePassword('password_confirmation')}
                     error={passwordErrors.password_confirmation}
                     required
                 />
@@ -288,6 +308,7 @@ const ProfileSettings = ({ mustVerifyEmail, status }: ProfileSettingsProps) => {
                                     event.currentTarget.value,
                                 )
                             }
+                            onBlur={() => validateDelete('password')}
                             error={deleteErrors.password}
                             ref={deletePasswordRef}
                             required

--- a/routes/auth.php
+++ b/routes/auth.php
@@ -11,29 +11,34 @@ use App\Http\Controllers\Auth\EmailVerificationNotificationController;
 use App\Http\Controllers\Auth\EmailVerificationPromptController;
 use App\Http\Controllers\Auth\PasswordResetLinkController;
 use App\Http\Controllers\Auth\VerifyEmailController;
+use App\Http\Middleware\HandlePrecognitiveRequests;
 use Illuminate\Support\Facades\Route;
 
 Route::middleware('guest')->group(function () {
     Route::get('register', RegisterUser::class)->name('register');
 
-    Route::post('register', RegisterUser::class);
+    Route::post('register', RegisterUser::class)
+        ->middleware(HandlePrecognitiveRequests::class);
 
     Route::get('login', [AuthenticatedSessionController::class, 'create'])
         ->name('login');
 
-    Route::post('login', [AuthenticatedSessionController::class, 'store']);
+    Route::post('login', [AuthenticatedSessionController::class, 'store'])
+        ->middleware(HandlePrecognitiveRequests::class);
 
     Route::get('forgot-password', [PasswordResetLinkController::class, 'create'])
         ->name('password.request');
 
     Route::post('forgot-password', [PasswordResetLinkController::class, 'store'])
-        ->name('password.email');
+        ->name('password.email')
+        ->middleware(HandlePrecognitiveRequests::class);
 
     Route::get('reset-password/{token}', ResetPassword::class)
         ->name('password.reset');
 
     Route::post('reset-password', ResetPassword::class)
-        ->name('password.store');
+        ->name('password.store')
+        ->middleware(HandlePrecognitiveRequests::class);
 });
 
 Route::middleware('auth')->group(function () {
@@ -51,9 +56,12 @@ Route::middleware('auth')->group(function () {
     Route::get('confirm-password', [ConfirmablePasswordController::class, 'show'])
         ->name('password.confirm');
 
-    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store']);
+    Route::post('confirm-password', [ConfirmablePasswordController::class, 'store'])
+        ->middleware(HandlePrecognitiveRequests::class);
 
-    Route::put('password', UpdatePassword::class)->name('password.update');
+    Route::put('password', UpdatePassword::class)
+        ->name('password.update')
+        ->middleware(HandlePrecognitiveRequests::class);
 
     Route::post('logout', [AuthenticatedSessionController::class, 'destroy'])
         ->name('logout');

--- a/routes/web.php
+++ b/routes/web.php
@@ -21,6 +21,7 @@ use App\Actions\User\ShowSettings;
 use App\Actions\User\UpdateProfile;
 use App\Actions\User\WipeAccount;
 use App\Features\Registration;
+use App\Http\Middleware\HandlePrecognitiveRequests;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 use Inertia\Inertia;
@@ -38,8 +39,10 @@ Route::get('/', function () {
 
 Route::middleware('auth')->group(function () {
     Route::get('/profile', ShowSettings::class)->name('profile.edit');
-    Route::patch('/profile', UpdateProfile::class)->name('profile.update');
-    Route::delete('/profile', DeleteAccount::class)->name('profile.destroy');
+    Route::patch('/profile', UpdateProfile::class)->name('profile.update')
+        ->middleware(HandlePrecognitiveRequests::class);
+    Route::delete('/profile', DeleteAccount::class)->name('profile.destroy')
+        ->middleware(HandlePrecognitiveRequests::class);
 
     Route::post('/profile/wipe', WipeAccount::class)->name('profile.wipe');
 
@@ -47,21 +50,25 @@ Route::middleware('auth')->group(function () {
     Route::get('/feeds', ShowFeedReader::class)->name('feeds.index');
 
     Route::middleware(['throttle:create_feed'])->group(function () {
-        Route::post('/feed', CreateNewFeed::class)->name('feed.store');
+        Route::post('/feed', CreateNewFeed::class)->name('feed.store')
+            ->middleware(HandlePrecognitiveRequests::class);
     });
     Route::delete('/feed/{feed_id}', UnsubscribeFromFeed::class)->name('feed.unsubscribe');
     Route::post('/feed/{feed_id}/refresh', RefreshFeedEntries::class)->name('feed.refresh');
     Route::post('/feed/{feed_id}/refresh-favicon', RefreshFavicon::class)->name('feed.refresh-favicon');
-    Route::patch('feed/{feed_id}', UpdateFeed::class)->name('feed.update');
+    Route::patch('feed/{feed_id}', UpdateFeed::class)->name('feed.update')
+        ->middleware(HandlePrecognitiveRequests::class);
     Route::post('/feed/{feed_id}/mark-read', MarkEntriesAsRead::class)->name('feed.mark-read');
 
     Route::patch('/entry/{entry_id}', UpdateEntryInteractions::class)->name('entry.update');
 
-    Route::post('category', CreateCategory::class)->name('category.store');
+    Route::post('category', CreateCategory::class)->name('category.store')
+        ->middleware(HandlePrecognitiveRequests::class);
     Route::delete('category/{category_id}', DeleteCategory::class)->name('category.delete')->whereNumber('category_id');
 
     Route::get('/import', ImportOPML::class)->name('import.index');
-    Route::post('/import', ImportOPML::class)->name('import.store');
+    Route::post('/import', ImportOPML::class)->name('import.store')
+        ->middleware(HandlePrecognitiveRequests::class);
     Route::get('/export', ExportOPML::class)->name('export.download');
 
     Route::get('/charts', ShowCharts::class)->name('charts.index');


### PR DESCRIPTION
## Summary

- Update `@inertiajs/react` to 2.3.1 to get Precognition support
- Add custom `HandlePrecognitiveRequests` middleware that works with `lorisleiva/laravel-actions`
- Add `PrecognitionControllerDispatcher` to handle the `ControllerDecorator` pattern used by laravel-actions
- Enable Precognition middleware on all form submission routes
- Add `withPrecognition()` and `onBlur` validation to all form components

## What is Precognition?

Laravel Precognition allows live validation of form fields using your backend validation rules without executing controller logic. When a user blurs out of a form field, a precognitive request is sent to Laravel which runs validation rules and returns errors instantly.

## Changes

### Backend
- `app/Http/Middleware/HandlePrecognitiveRequests.php` - Custom middleware that overrides the dispatcher binding
- `app/Support/PrecognitionControllerDispatcher.php` - Custom dispatcher that extracts the actual action class from laravel-actions' `ControllerDecorator`
- Routes updated to use `HandlePrecognitiveRequests` middleware

### Frontend
- All forms now use `.withPrecognition('method', route)` 
- All inputs have `onBlur={() => validate('fieldname')}` for real-time validation

## Test plan

- [ ] Test registration form - email uniqueness should validate in real-time
- [ ] Test login form
- [ ] Test profile update form
- [ ] Test password change form  
- [ ] Test add feed form
- [ ] Test add category form
- [ ] Verify existing form submissions still work correctly

## References

- [Inertia 2.3 Adds Precognition Support](https://laravel-news.com/inertia-2-3-0)
- [Laravel Actions + Precognition workaround](https://github.com/lorisleiva/laravel-actions/discussions/249)