### PR TITLE
Enable SimplePie cache for ETag/Last-Modified support

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Larafeed is a simple feed reader.
   - Prefetching is leveraged to make the app feel snappy
 - Feed parsing is powered by [SimplePie](https://github.com/simplepie/simplepie)
   - Through [willvincent/feeds](https://github.com/willvincent/feeds)
+  - Polite to publishers: uses ETag/Last-Modified headers to avoid re-downloading unchanged feeds
 - Summary generation is powered by Gemini through [echolabsdev/prism](https://github.com/echolabsdev/prism)
 - Background jobs are powered by Laravel queues
 - Favicon fetching is powered by [ash-jc-allen/favicon-fetcher](https://github.com/ash-jc-allen/favicon-fetcher)

--- a/config/feeds.php
+++ b/config/feeds.php
@@ -21,9 +21,12 @@ return [
     |--------------------------------------------------------------------------
     |
     | Life of cache, in seconds
+    | We set it very short in Larafeed to force conditional requests
+    | (ETag/Last-Modified) on each fetch while still benefiting from
+    | HTTP 304 responses when feeds haven't changed.
     |
     */
-    'cache.life' => 3600,
+    'cache.life' => 60,
 
     /*
     |--------------------------------------------------------------------------
@@ -33,7 +36,7 @@ return [
     | Whether to disable the cache.
     |
     */
-    'cache.disabled' => true,
+    'cache.disabled' => false,
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
Enables conditional HTTP requests when fetching feeds. Servers can return 304 Not Modified when feeds haven't changed, saving bandwidth and being polite to publishers.