### PR TITLE
Refactor URL param handling to use query-string

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,9 @@
     "requires": true,
     "packages": {
         "": {
+            "dependencies": {
+                "query-string": "^9.3.1"
+            },
             "devDependencies": {
                 "@biomejs/biome": "^2.3.10",
                 "@datadog/browser-rum": "^6.25.1",
@@ -2477,6 +2480,15 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/decode-uri-component": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.4.1.tgz",
+            "integrity": "sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            }
+        },
         "node_modules/deepmerge": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
@@ -2745,6 +2757,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
+            }
+        },
+        "node_modules/filter-obj": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/filter-obj/-/filter-obj-5.1.0.tgz",
+            "integrity": "sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/follow-redirects": {
@@ -3575,6 +3599,23 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/query-string": {
+            "version": "9.3.1",
+            "resolved": "https://registry.npmjs.org/query-string/-/query-string-9.3.1.tgz",
+            "integrity": "sha512-5fBfMOcDi5SA9qj5jZhWAcTtDfKF5WFdd2uD9nVNlbxVv1baq65aALy6qofpNEGELHvisjjasxQp7BlM9gvMzw==",
+            "license": "MIT",
+            "dependencies": {
+                "decode-uri-component": "^0.4.1",
+                "filter-obj": "^5.1.0",
+                "split-on-first": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
         "node_modules/react": {
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -4007,6 +4048,18 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.10.0"
+            }
+        },
+        "node_modules/split-on-first": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/split-on-first/-/split-on-first-3.0.0.tgz",
+            "integrity": "sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/string-width": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     },
     "devDependencies": {
         "@biomejs/biome": "^2.3.10",
-        "lefthook": "^2.0.13",
         "@datadog/browser-rum": "^6.25.1",
         "@gfazioli/mantine-split-pane": "^1.1.5",
         "@headlessui/react": "^2.2.9",
@@ -33,6 +32,7 @@
         "concurrently": "^9.2.1",
         "dayjs": "^1.11.19",
         "laravel-vite-plugin": "^2.0",
+        "lefthook": "^2.0.13",
         "postcss": "^8.5.6",
         "postcss-preset-mantine": "^1.18.0",
         "postcss-simple-vars": "^7.0.1",
@@ -43,5 +43,8 @@
         "recharts": "^2.15.4",
         "typescript": "^5.9.3",
         "vite": "^7.3"
+    },
+    "dependencies": {
+        "query-string": "^9.3.1"
     }
 }

--- a/resources/js/Pages/Reader/Components/DeleteFeedModal.tsx
+++ b/resources/js/Pages/Reader/Components/DeleteFeedModal.tsx
@@ -1,6 +1,7 @@
 import { router } from '@inertiajs/react';
 import { Button, Group, Modal, Text } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
+import { getUrlParam, getUrlParams } from '@/utils/queryString';
 
 interface DeleteFeedModalProps {
     feed: { name: string; id: number };
@@ -34,11 +35,11 @@ export const DeleteFeedModal = ({
                                     withBorder: true,
                                 });
 
-                                const params = new URLSearchParams(
-                                    window.location.search,
-                                );
-                                if (params.get('feed') === feed.id.toString()) {
-                                    params.delete('feed');
+                                const params = { ...getUrlParams() };
+                                if (
+                                    getUrlParam('feed') === feed.id.toString()
+                                ) {
+                                    delete params.feed;
                                 }
 
                                 router.visit(route('feeds.index'), {
@@ -49,9 +50,7 @@ export const DeleteFeedModal = ({
                                         'unreadEntriesCount',
                                         'readEntriesCount',
                                     ],
-                                    data: {
-                                        ...Object.fromEntries(params),
-                                    },
+                                    data: params,
                                     preserveScroll: true,
                                     preserveState: true,
                                 });

--- a/resources/js/Pages/Reader/CurrentEntryPane.tsx
+++ b/resources/js/Pages/Reader/CurrentEntryPane.tsx
@@ -36,6 +36,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { readingTime } from 'reading-time-estimator';
 import { FaviconImage } from '@/Components/FaviconImage/FaviconImage';
 import { FeedMenu } from '@/Components/FeedMenu';
+import { getUrlParams } from '@/utils/queryString';
 import classes from './CurrentEntryPane.module.css';
 
 dayjs.extend(relativeTime);
@@ -108,18 +109,16 @@ export default function CurrentEntryPane({
     };
 
     const updateRead = () => {
-        const urlParams = new URLSearchParams(window.location.search);
+        const urlParams = { ...getUrlParams() };
 
         if (currententry.read_at) {
-            urlParams.set('read', 'false');
+            urlParams.read = 'false';
         } else {
-            urlParams.set('read', 'true');
+            urlParams.read = 'true';
         }
 
         router.visit('feeds', {
-            data: {
-                ...Object.fromEntries(urlParams),
-            },
+            data: urlParams,
             preserveScroll: true,
             preserveState: true,
             only: [
@@ -163,14 +162,12 @@ export default function CurrentEntryPane({
             value === 'summary' &&
             !window.location.search.includes('summarize')
         ) {
-            const urlParams = new URLSearchParams(window.location.search);
-            urlParams.set('summarize', 'true');
+            const urlParams = { ...getUrlParams() };
+            urlParams.summarize = 'true';
 
             router.visit('feeds', {
                 only: ['summary'],
-                data: {
-                    ...Object.fromEntries(urlParams),
-                },
+                data: urlParams,
                 preserveScroll: true,
                 preserveState: true,
             });
@@ -179,14 +176,12 @@ export default function CurrentEntryPane({
             value === 'content' &&
             window.location.search.includes('summarize')
         ) {
-            const urlParams = new URLSearchParams(window.location.search);
-            urlParams.delete('summarize');
+            const urlParams = { ...getUrlParams() };
+            delete urlParams.summarize;
 
             router.visit('feeds', {
                 only: ['summary'],
-                data: {
-                    ...Object.fromEntries(urlParams),
-                },
+                data: urlParams,
                 preserveScroll: true,
                 preserveState: true,
             });

--- a/resources/js/Pages/Reader/EntryListPane.tsx
+++ b/resources/js/Pages/Reader/EntryListPane.tsx
@@ -17,6 +17,7 @@ import relativeTime from 'dayjs/plugin/relativeTime';
 import utc from 'dayjs/plugin/utc';
 import { useCallback, useEffect, useRef } from 'react';
 import { FaviconImage } from '@/Components/FaviconImage/FaviconImage';
+import { getUrlParams } from '@/utils/queryString';
 import classes from './EntryListPane.module.css';
 
 dayjs.extend(relativeTime);
@@ -54,9 +55,7 @@ export default function EntryListPane({
                     'readEntriesCount',
                 ],
                 data: {
-                    ...Object.fromEntries(
-                        new URLSearchParams(window.location.search),
-                    ),
+                    ...getUrlParams(),
                     entry: entries.data[newIndex].id,
                 },
                 preserveScroll: true,
@@ -71,13 +70,13 @@ export default function EntryListPane({
     ]);
 
     const entryList = entries.data.map((entry) => {
-        const urlParams = new URLSearchParams(window.location.search);
+        const urlParams = { ...getUrlParams() };
 
-        urlParams.delete('summarize');
-        urlParams.delete('read');
-        urlParams.set('entry', entry.id.toString());
+        delete urlParams.summarize;
+        delete urlParams.read;
+        urlParams.entry = entry.id.toString();
 
-        const data = Object.fromEntries(urlParams);
+        const data = urlParams;
         return (
             <Link
                 key={entry.id}
@@ -195,9 +194,7 @@ export default function EntryListPane({
                         preserveState: true,
                         prefetch: true,
                         data: {
-                            ...Object.fromEntries(
-                                new URLSearchParams(window.location.search),
-                            ),
+                            ...getUrlParams(),
                             page,
                         },
                     })}
@@ -211,9 +208,7 @@ export default function EntryListPane({
                             preserveState
                             prefetch
                             data={{
-                                ...Object.fromEntries(
-                                    new URLSearchParams(window.location.search),
-                                ),
+                                ...getUrlParams(),
                                 page: 1,
                             }}
                         />
@@ -225,9 +220,7 @@ export default function EntryListPane({
                             preserveState
                             prefetch
                             data={{
-                                ...Object.fromEntries(
-                                    new URLSearchParams(window.location.search),
-                                ),
+                                ...getUrlParams(),
                                 page: Math.max(1, entries.current_page - 1),
                             }}
                         />
@@ -240,9 +233,7 @@ export default function EntryListPane({
                             preserveState
                             prefetch
                             data={{
-                                ...Object.fromEntries(
-                                    new URLSearchParams(window.location.search),
-                                ),
+                                ...getUrlParams(),
                                 page: Math.min(
                                     entries.last_page,
                                     entries.current_page + 1,
@@ -257,9 +248,7 @@ export default function EntryListPane({
                             preserveState
                             prefetch
                             data={{
-                                ...Object.fromEntries(
-                                    new URLSearchParams(window.location.search),
-                                ),
+                                ...getUrlParams(),
                                 page: entries.last_page,
                             }}
                         />

--- a/resources/js/Pages/Reader/Sidebar.tsx
+++ b/resources/js/Pages/Reader/Sidebar.tsx
@@ -45,6 +45,7 @@ import utc from 'dayjs/plugin/utc';
 import { type FormEventHandler, type ReactNode, useState } from 'react';
 import { FaviconImage } from '@/Components/FaviconImage/FaviconImage';
 import { FeedMenu } from '@/Components/FeedMenu';
+import { getUrlParam, getUrlParams } from '@/utils/queryString';
 import classes from './Sidebar.module.css';
 
 dayjs.extend(relativeTime);
@@ -133,11 +134,7 @@ export default function Sidebar({
                 opened={opened}
                 close={close}
                 categories={sortedCategories}
-                initialFeedURL={
-                    new URLSearchParams(window.location.search).get(
-                        'addFeedUrl',
-                    ) || undefined
-                }
+                initialFeedURL={getUrlParam('addFeedUrl') || undefined}
             />
             <AppShell.Navbar>
                 <AppShell.Section pr="md" pl="md" pt="md">
@@ -290,23 +287,22 @@ const FilterLink = function FilterLink({
     readEntriesCount: number;
     unreadEntriesCount: number;
 }) {
-    const params = new URLSearchParams(window.location.search);
-    params.delete('page');
+    const params = { ...getUrlParams() };
+    delete params.page;
 
-    const currentFilter = params.get('filter');
+    const currentFilter = getUrlParam('filter');
     if (currentFilter === label.toLowerCase()) {
         // Clicking again -> remove the filter
-        params.delete('filter');
+        delete params.filter;
     } else {
-        params.set('filter', label.toLowerCase());
+        params.filter = label.toLowerCase();
     }
 
     return (
         <Link
             key={label}
             className={`${classes.mainLink} ${
-                label.toLowerCase() ===
-                new URLSearchParams(window.location.search).get('filter')
+                label.toLowerCase() === getUrlParam('filter')
                     ? classes.activeFeed
                     : ''
             }`}
@@ -314,9 +310,7 @@ const FilterLink = function FilterLink({
             only={['entries']}
             preserveScroll
             preserveState
-            data={{
-                ...Object.fromEntries(params),
-            }}
+            data={params}
             prefetch
             as="div"
         >
@@ -361,15 +355,15 @@ export const FeedLinksGroup = ({
     const [manualOpened, setManualOpened] = useState<boolean | null>(null);
     const opened = manualOpened ?? autoOpened;
 
-    const params = new URLSearchParams(window.location.search);
-    params.delete('feed');
+    const params = { ...getUrlParams() };
+    delete params.feed;
 
-    const currentCategory = params.get('category');
+    const currentCategory = getUrlParam('category');
     if (currentCategory === category.id.toString()) {
         // Clicking again -> unselect the category
-        params.delete('category');
+        delete params.category;
     } else {
-        params.set('category', category.id.toString());
+        params.category = category.id.toString();
     }
 
     return (
@@ -379,9 +373,7 @@ export const FeedLinksGroup = ({
             prefetch
             preserveScroll
             preserveState
-            data={{
-                ...Object.fromEntries(params),
-            }}
+            data={params}
             as="div"
         >
             <NavLink
@@ -394,16 +386,10 @@ export const FeedLinksGroup = ({
                         only: ['entries'],
                         preserveScroll: true,
                         preserveState: true,
-                        data: {
-                            ...Object.fromEntries(params),
-                        },
+                        data: params,
                     });
                 }}
-                active={
-                    new URLSearchParams(window.location.search).get(
-                        'category',
-                    ) === category.id.toString()
-                }
+                active={getUrlParam('category') === category.id.toString()}
                 label={
                     <CategoryHeader
                         category={category}
@@ -951,11 +937,11 @@ const FeedLink = function FeedLink({
             .fromNow()}`;
     })();
 
-    const urlParams = new URLSearchParams(window.location.search);
-    urlParams.delete('filter');
-    urlParams.delete('page');
-    urlParams.delete('category');
-    urlParams.set('feed', feed.id.toString());
+    const urlParams = { ...getUrlParams() };
+    delete urlParams.filter;
+    delete urlParams.page;
+    delete urlParams.category;
+    urlParams.feed = feed.id.toString();
 
     return (
         <div
@@ -995,8 +981,7 @@ const FeedLink = function FeedLink({
                     ref={ref}
                     key={feed.id}
                     className={`${classes.collectionLink} ${
-                        feed.id.toString() ===
-                        new URLSearchParams(window.location.search).get('feed')
+                        feed.id.toString() === getUrlParam('feed')
                             ? classes.activeFeed
                             : ''
                     }`}
@@ -1005,9 +990,7 @@ const FeedLink = function FeedLink({
                     only={['feed', 'entries']}
                     preserveScroll
                     preserveState
-                    data={{
-                        ...Object.fromEntries(urlParams),
-                    }}
+                    data={urlParams}
                     prefetch
                 >
                     <Indicator

--- a/resources/js/utils/queryString.ts
+++ b/resources/js/utils/queryString.ts
@@ -1,0 +1,35 @@
+import queryString, { type ParsedQuery } from 'query-string';
+
+/**
+ * Parse the current URL's query string into an object
+ */
+export function getUrlParams(): ParsedQuery<string> {
+    return queryString.parse(window.location.search);
+}
+
+/**
+ * Stringify an object into a query string (without leading ?)
+ */
+export function stringifyParams(
+    params: Record<string, unknown>,
+    options?: queryString.StringifyOptions,
+): string {
+    return queryString.stringify(params, {
+        arrayFormat: 'bracket',
+        skipNull: true,
+        skipEmptyString: true,
+        ...options,
+    });
+}
+
+/**
+ * Get a specific parameter from the current URL
+ */
+export function getUrlParam(key: string): string | null {
+    const params = getUrlParams();
+    const value = params[key];
+    if (Array.isArray(value)) {
+        return value[0] ?? null;
+    }
+    return value ?? null;
+}


### PR DESCRIPTION
## Summary
- Add `query-string` library for cleaner URL parameter handling
- Create `queryString.ts` utility with `getUrlParams()` and `getUrlParam()` helpers
- Refactor all components using `URLSearchParams` to use the new utilities

## Changes
- Sidebar.tsx, EntryListPane.tsx, CurrentEntryPane.tsx, DeleteFeedModal.tsx