### PR TITLE
Fix telemetry schema conflict

### DIFF
--- a/internal/handler/validate.go
+++ b/internal/handler/validate.go
@@ -67,7 +67,7 @@ func validateRequest(req any) map[string]string {
 func extractLabels(req any) map[string]string {
 	labels := map[string]string{}
 	t := reflect.TypeOf(req)
-	if t.Kind() == reflect.Ptr {
+	if t.Kind() == reflect.Pointer {
 		t = t.Elem()
 	}
 	for i := 0; i < t.NumField(); i++ {

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -29,11 +29,7 @@ func Setup(ctx context.Context, serviceName, environment string) (shutdown func(
 
 	res, err := resource.Merge(
 		resource.Default(),
-		resource.NewWithAttributes(
-			semconv.SchemaURL,
-			semconv.ServiceName(serviceName),
-			semconv.DeploymentEnvironmentName(environment),
-		),
+		appResource(serviceName, environment),
 	)
 	if err != nil {
 		return nil, err
@@ -51,4 +47,13 @@ func Setup(ctx context.Context, serviceName, environment string) (shutdown func(
 	http.DefaultTransport = otelhttp.NewTransport(http.DefaultTransport)
 
 	return tp.Shutdown, nil
+}
+
+func appResource(serviceName, environment string) *resource.Resource {
+	// The default resource schema can move independently across OTel versions.
+	// Keep app-level attributes schemaless so startup does not fail on schema URL conflicts.
+	return resource.NewSchemaless(
+		semconv.ServiceName(serviceName),
+		semconv.DeploymentEnvironmentName(environment),
+	)
 }

--- a/internal/telemetry/telemetry_test.go
+++ b/internal/telemetry/telemetry_test.go
@@ -1,0 +1,35 @@
+package telemetry
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/sdk/resource"
+)
+
+func TestAppResourceMergesWithDifferentSchemaURL(t *testing.T) {
+	defaultResource := resource.NewWithAttributes(
+		"https://opentelemetry.io/schemas/1.41.0",
+		attribute.String("service.name", "default-service"),
+	)
+
+	res, err := resource.Merge(defaultResource, appResource("larafeed", "production"))
+
+	require.NoError(t, err)
+	require.Equal(t, "https://opentelemetry.io/schemas/1.41.0", res.SchemaURL())
+
+	attrs := resourceAttributes(res)
+	require.Equal(t, "larafeed", attrs["service.name"])
+	require.Equal(t, "production", attrs["deployment.environment.name"])
+}
+
+func resourceAttributes(res *resource.Resource) map[string]string {
+	attrs := make(map[string]string, res.Len())
+	iter := res.Iter()
+	for iter.Next() {
+		attr := iter.Attribute()
+		attrs[string(attr.Key)] = attr.Value.AsString()
+	}
+	return attrs
+}


### PR DESCRIPTION
## Summary

- Make the app-provided OpenTelemetry resource attributes schemaless before merging them with the default resource.
- Add a regression test covering a merge with a newer schema URL (`https://opentelemetry.io/schemas/1.41.0`).

## Root Cause

Production startup failed when `resource.Merge` saw two different non-empty schema URLs: the app resource used semconv `1.40.0`, while another resource in prod used `1.41.0`. OpenTelemetry treats that as a merge conflict and returned an initialization error.

## Impact

Telemetry still reports `service.name` and `deployment.environment.name`, but app startup no longer depends on every resource sharing the exact same semantic convention schema URL.

## Validation

- `go test ./internal/telemetry`
- `git diff --check`
- `golangci-lint` via pre-commit hook

`go test -short ./...` and the pre-commit `go-test` hook were blocked locally because testcontainers could not find a Docker provider (`rootless Docker not found`).