### PR TITLE
Fix encoded feed titles

### DIFF
--- a/internal/db/entries_manual.go
+++ b/internal/db/entries_manual.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"encoding/json"
+	"html"
 	"time"
 )
 
@@ -56,7 +57,7 @@ func (e ReaderEntry) MarshalJSON() ([]byte, error) {
 
 	out := entryJSON{
 		ID:              e.ID,
-		Title:           e.Title,
+		Title:           html.UnescapeString(e.Title),
 		URL:             e.URL,
 		Author:          e.Author,
 		Content:         e.Content,

--- a/internal/db/entries_test.go
+++ b/internal/db/entries_test.go
@@ -16,13 +16,13 @@ func TestReaderEntry_MarshalJSON(t *testing.T) {
 	t.Run("nests feed fields into feed sub-object", func(t *testing.T) {
 		now := time.Now()
 		entry := ReaderEntry{
-			ID:          1,
-			FeedID:      42,
-			Title:       "Test Entry",
-			URL:         "https://example.com/post",
-			PublishedAt: now,
-			FeedName:    "Example Feed",
-			FaviconURL:  strPtr("https://example.com/favicon.ico"),
+			ID:            1,
+			FeedID:        42,
+			Title:         "Test Entry",
+			URL:           "https://example.com/post",
+			PublishedAt:   now,
+			FeedName:      "Example Feed",
+			FaviconURL:    strPtr("https://example.com/favicon.ico"),
 			FaviconIsDark: boolPtr(false),
 		}
 
@@ -72,6 +72,26 @@ func TestReaderEntry_MarshalJSON(t *testing.T) {
 
 		feed := result["feed"].(map[string]any)
 		assert.Equal(t, "Custom Name", feed["name"])
+	})
+
+	t.Run("decodes HTML entities in title as plain text", func(t *testing.T) {
+		entry := ReaderEntry{
+			ID:          1,
+			FeedID:      42,
+			Title:       "Here&#8217;s &amp; &lt;script&gt;alert(1)&lt;/script&gt;",
+			URL:         "https://example.com",
+			PublishedAt: time.Now(),
+			FeedName:    "Example Feed",
+		}
+
+		data, err := json.Marshal(entry)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), "<script>")
+
+		var result map[string]any
+		err = json.Unmarshal(data, &result)
+		require.NoError(t, err)
+		assert.Equal(t, "Here’s & <script>alert(1)</script>", result["title"])
 	})
 
 	t.Run("uses original name when custom name is empty", func(t *testing.T) {


### PR DESCRIPTION
## What changed

- Decode HTML entities in reader entry titles during JSON serialization.
- Add regression coverage for numeric and named entities.
- Verify decoded markup remains plain JSON text and is not rendered as trusted HTML.

## Why

Some feeds provide titles containing encoded entities such as `&#8217;`. These values were stored and sent to React unchanged, causing readers to see text such as `Here&#8217;s` instead of `Here’s`.

Decoding at the reader serialization boundary fixes existing stored entries as well as future responses while preserving React's safe plain-text rendering.

## Impact

Entry titles display their intended punctuation in both the entry list and current-entry view. No database migration is required.

## Validation

- `go test ./internal/db ./internal/service`
- `go test -short ./...`
- `golangci-lint run ./...`
- `git diff --check`
